### PR TITLE
[WIP] Invocation Contexts

### DIFF
--- a/Commander/Shape.swift
+++ b/Commander/Shape.swift
@@ -59,11 +59,11 @@ final class MoveCommand: Command {
         self.init(moveable: moveable, offset: offset)
     }
 
-    func invoke() {
+    func invoke(context: InvocationContext? = nil) {
         self.moveable.move(by: self.offset)
     }
 
-    func reverse() {
+    func reverse(context: InvocationContext? = nil) {
         self.moveable.move(by: self.inverseOffset)
     }
 }
@@ -89,12 +89,12 @@ final class CollissionDetectionCommand: Command {
         self.moveables = moveables
     }
 
-    func invoke() {
-        self.command.invoke()
+    func invoke(context: InvocationContext? = nil) {
+        self.command.invoke(context: context)
     }
 
-    func reverse() {
-        self.command.reverse()
+    func reverse(context: InvocationContext? = nil) {
+        self.command.reverse(context: context)
     }
 
     private func makeCommand() -> Command {
@@ -149,7 +149,7 @@ final class DisplayCommand: Invokeable {
         self.outputStreamPointer = outputStream
     }
 
-    func invoke() {
+    func invoke(context: InvocationContext? = nil) {
         self.outputStreamPointer.pointee.write("Priting displayable with title: \(self.displayable.title)")
     }
 }

--- a/Commands/BlockCommand.swift
+++ b/Commands/BlockCommand.swift
@@ -29,11 +29,11 @@ public final class BlockCommand {
 
 extension BlockCommand: Command {
 
-    public func invoke() {
+    public func invoke(context: InvocationContext? = nil) {
         self.executionBlock()
     }
 
-    public func reverse() {
+    public func reverse(context: InvocationContext? = nil) {
         self.reverseExecutionBlock()
     }
 }

--- a/Commands/Command.swift
+++ b/Commands/Command.swift
@@ -12,5 +12,5 @@ import Foundation
 /// A Command is an Invokable that mutates state and needs to be reversible
 public protocol Command: Invokeable {
 
-    func reverse()
+    func reverse(context: InvocationContext?)
 }

--- a/Commands/CommandStore.swift
+++ b/Commands/CommandStore.swift
@@ -35,7 +35,7 @@ public final class CommandStore {
 
 extension CommandStore: InvokeableHandler {
 
-    public func handleInvokeable(_ invokeable: Invokeable) {
+    public func handleInvokeable(_ invokeable: Invokeable, context: InvocationContext?) {
         guard let command = invokeable as? Command else { return }
 
         self.commands.append(command)

--- a/Commands/GroupCommand.swift
+++ b/Commands/GroupCommand.swift
@@ -33,11 +33,11 @@ extension GroupCommand: Command {
         return "<\(type(of: self))> {\n" + commandsDescription + "\n}"
     }
 
-    public func invoke() {
-        self.commands.forEach { $0.invoke() }
+    public func invoke(context: InvocationContext?) {
+        self.commands.forEach { $0.invoke(context: context) }
     }
 
-    public func reverse() {
-        self.commands.reversed().forEach { $0.reverse() }
+    public func reverse(context: InvocationContext?) {
+        self.commands.reversed().forEach { $0.reverse(context: context) }
     }
 }

--- a/Commands/InverseCommand.swift
+++ b/Commands/InverseCommand.swift
@@ -26,11 +26,11 @@ public final class InverseCommand {
 
 extension InverseCommand: Command {
 
-    public func invoke() {
-        self.command.reverse()
+    public func invoke(context: InvocationContext?) {
+        self.command.reverse(context: context)
     }
 
-    public func reverse() {
-        self.command.invoke()
+    public func reverse(context: InvocationContext?) {
+        self.command.invoke(context: context)
     }
 }

--- a/Commands/Invokeable.swift
+++ b/Commands/Invokeable.swift
@@ -9,10 +9,12 @@
 import Foundation
 
 
+public protocol InvocationContext { }
+
 /// Invokeables can be invoked by a Dispatcher
 public protocol Invokeable: AnyObject, CustomStringConvertible {
 
-    func invoke()
+    func invoke(context: InvocationContext?)
 }
 
 // MARK: - CustomStringConvertible

--- a/Commands/InvokeableHandler.swift
+++ b/Commands/InvokeableHandler.swift
@@ -11,9 +11,9 @@ import Foundation
 
 /// an InvokeableHandler is any object, that can trigger actions based on a specific invokeable
 /// All handlers are called by the Dispatcher, whenever an Invokeable is dispatched
-public protocol InvokeableHandler: class {
+public protocol InvokeableHandler: AnyObject {
 
     var isEnabled: Bool { get set }
 
-    func handleInvokeable(_ invokeable: Invokeable)
+    func handleInvokeable(_ invokeable: Invokeable, context: InvocationContext?)
 }

--- a/Commands/InvokeableLogger.swift
+++ b/Commands/InvokeableLogger.swift
@@ -30,7 +30,7 @@ public final class InvokeableLogger {
 
 extension InvokeableLogger: InvokeableHandler {
 
-    public func handleInvokeable(_ invokeable: Invokeable) {
+    public func handleInvokeable(_ invokeable: Invokeable, context: InvocationContext?) {
         let description = invokeable.description
 
         if let outputStream = self.outputStreamPointer {

--- a/Commands/Invoker.swift
+++ b/Commands/Invoker.swift
@@ -28,7 +28,7 @@ public final class Invoker {
 
 extension Invoker: InvokeableHandler {
 
-    public func handleInvokeable(_ invokeable: Invokeable) {
-        invokeable.invoke()
+    public func handleInvokeable(_ invokeable: Invokeable, context: InvocationContext?) {
+        invokeable.invoke(context: context)
     }
 }

--- a/Commands/ProduceCommand.swift
+++ b/Commands/ProduceCommand.swift
@@ -30,11 +30,11 @@ open class ProduceCommand {
 
 extension ProduceCommand: Command {
 
-    public func invoke() {
-        self.producedCommand.invoke()
+    public func invoke(context: InvocationContext?) {
+        self.producedCommand.invoke(context: context)
     }
 
-    public func reverse() {
-        self.producedCommand.reverse()
+    public func reverse(context: InvocationContext?) {
+        self.producedCommand.reverse(context: context)
     }
 }

--- a/Commands/TargetActionCommand.swift
+++ b/Commands/TargetActionCommand.swift
@@ -29,11 +29,11 @@ public final class TargetActionCommand {
 
 extension TargetActionCommand: Command {
 
-    public func invoke() {
+    public func invoke(context: InvocationContext? = nil) {
         _ = self.target?.perform(self.action)
     }
 
-    public func reverse() {
+    public func reverse(context: InvocationContext? = nil) {
         _ = self.target?.perform(self.reverseAction)
     }
 }


### PR DESCRIPTION
closes #2 

Opening this up for discussion, as I feel like we might hit a wall here. I did not yet think this through, but passing in the invocation context as parameter opens up 2 problems so far:

 1. I couldn't find a way to make the invocationContext generic (and unknown in the framework), so I had to fall back to an empty protocol and the correct context type would need to be asserted at runtime. I don't like that, but potentially there's a solution for the problem I don't see yet.
 2. it adds complexity. Currently `CollissionDetectionCommand` from the sample doesn't work with this approach (less of an issue I guess), but we also need to pass around a lot of context and e.g. store them in the UndoManager. Not sure the added complexity is worth it.